### PR TITLE
Add funding metadata

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,15 @@
+# These are supported funding model platforms
+
+github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: dmeloper
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+polar: # Replace with a single Polar username
+buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
+thanks_dev: # Replace with a single thanks.dev username
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/.github/workflows/public-export-approval.yml
+++ b/.github/workflows/public-export-approval.yml
@@ -52,6 +52,7 @@ jobs:
             '.github/ISSUE_TEMPLATE/feature_request.yml',
             '.github/ISSUE_TEMPLATE/support_question.yml',
             '.github/ISSUE_TEMPLATE/config.yml',
+            '.github/FUNDING.yml',
             '.github/PULL_REQUEST_TEMPLATE.md',
             '.github/workflows/public-export-approval.yml'
           )


### PR DESCRIPTION
﻿## Summary / 요약

Metadata-only public PR for GitHub funding metadata.

GitHub funding metadata를 public source-owned metadata로 등록하고, public export validation에서 해당 파일을 required metadata로 확인하도록 업데이트합니다.

## Scope / 범위

- Adds `.github/FUNDING.yml` with Ko-fi funding metadata.
- Updates `public-export-approval` to require `.github/FUNDING.yml` on public release branches.
- No skin runtime, helper, package, release asset, or tag changes.

## Testing / 테스트

- Source-side export config parses successfully.
- `Publish-GitHubDistribution.ps1 -ValidateOnly` passed after adding funding metadata.
- PR branch diff contains only `.github/FUNDING.yml` and `.github/workflows/public-export-approval.yml`.
