### PR TITLE
Harden public metadata PR flow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,14 +4,15 @@ Describe the change.
 
 변경 내용을 적어주세요.
 
-For community PRs, describe the proposal. Accepted changes are applied through the maintainer private development workspace and published back here through a release approval PR.
+For community PRs, describe the proposal. Accepted changes are applied through the maintainer private development workspace and published back here through a release approval PR or metadata-only PR, depending on the change.
 
-커뮤니티 PR이라면 proposal 내용을 적어주세요. 채택된 변경은 maintainer의 private development workspace에 반영된 뒤 release approval PR을 통해 이곳에 다시 게시됩니다.
+커뮤니티 PR이라면 proposal 내용을 적어주세요. 채택된 변경은 maintainer의 private development workspace에 반영된 뒤 변경 유형에 따라 release approval PR 또는 metadata-only PR을 통해 이곳에 다시 게시됩니다.
 
 ## PR Type / PR 유형
 
 - [ ] Community proposal PR / 커뮤니티 proposal PR
 - [ ] Maintainer release approval PR / maintainer release approval PR
+- [ ] Maintainer metadata-only PR / maintainer metadata-only PR
 
 Community PRs are reviewed as proposal and review input. They do not need to use a `publish/v<version>` branch, and a `public-export-approval` failure on a community branch may be an intentional guard rather than a review blocker.
 
@@ -20,6 +21,10 @@ Community PRs are reviewed as proposal and review input. They do not need to use
 Maintainer release approval PRs are maintainer-only. They use `publish/v<version>` and must pass `public-export-approval` before manual merge.
 
 Maintainer release approval PR은 maintainer 전용입니다. `publish/v<version>`을 사용하고 수동 merge 전에 `public-export-approval`을 통과해야 합니다.
+
+Maintainer metadata-only PRs are maintainer-only. They use `publish/metadata-<topic>`, may change only approved public metadata paths, and do not publish release tags or assets.
+
+Maintainer metadata-only PR은 maintainer 전용입니다. `publish/metadata-<topic>`을 사용하고 승인된 public metadata 경로만 변경할 수 있으며 release tag나 asset을 배포하지 않습니다.
 
 ## Testing / 테스트
 
@@ -39,13 +44,13 @@ Add screenshots or recordings for visual changes.
 - [ ] I did not include private paths, logs, backups, generated runtime state, generated caches, built distribution trees, or ZIP/RMSKIN release assets.
 - [ ] Rainmeter `.ini` / `.inc` files remain UTF-16 LE with BOM if touched.
 - [ ] Lua changes were syntax-checked if touched.
-- [ ] Public-facing text avoids internal workflow terminology.
+- [ ] Public-facing text avoids private/internal workflow terminology except necessary public branch/check policy terms.
 - [ ] Packaging/update behavior is noted if affected.
 - [ ] 이 PR을 proposal 또는 검토 입력으로 설명했습니다.
 - [ ] 개인 경로, 로그, 백업, 생성된 런타임 상태, 생성 캐시, 빌드된 배포 트리, ZIP/RMSKIN release asset을 포함하지 않았습니다.
 - [ ] Rainmeter `.ini` / `.inc` 파일을 수정했다면 UTF-16 LE BOM을 유지했습니다.
 - [ ] Lua를 수정했다면 문법 검사를 했습니다.
-- [ ] 공개 문구에 내부 워크플로 용어를 쓰지 않았습니다.
+- [ ] 공개 문구에 private/internal workflow 용어를 쓰지 않았으며, 필요한 public branch/check policy 용어만 사용했습니다.
 - [ ] 패키징/업데이트 영향이 있다면 설명했습니다.
 
 ## Maintainer Release Approval Checklist / Maintainer 릴리즈 승인 체크리스트
@@ -58,3 +63,16 @@ Add screenshots or recordings for visual changes.
 - [ ] 브랜치가 `publish/v<version>`입니다.
 - [ ] `public-export-approval` 검사를 통과했습니다.
 - [ ] diff에는 승인된 공개 배포 내용과 공개 metadata만 포함되어 있습니다.
+
+## Maintainer Metadata-Only Checklist / Maintainer metadata-only 체크리스트
+
+- [ ] This is a maintainer-only metadata PR.
+- [ ] The branch is `publish/metadata-<topic>`.
+- [ ] The `public-export-approval` check passes.
+- [ ] The diff contains only approved public metadata paths.
+- [ ] This PR does not publish a GitHub Release, tag, ZIP, RMSKIN, or runtime payload.
+- [ ] 이 PR은 maintainer 전용 metadata PR입니다.
+- [ ] 브랜치가 `publish/metadata-<topic>`입니다.
+- [ ] `public-export-approval` 검사를 통과했습니다.
+- [ ] diff에는 승인된 public metadata 경로만 포함되어 있습니다.
+- [ ] 이 PR은 GitHub Release, tag, ZIP, RMSKIN, runtime payload를 배포하지 않습니다.

--- a/.github/workflows/public-export-approval.yml
+++ b/.github/workflows/public-export-approval.yml
@@ -16,18 +16,98 @@ jobs:
     steps:
       - name: Check out pull request
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Validate public release branch
         shell: pwsh
+        env:
+          PR_HEAD_REF: ${{ github.head_ref }}
+          PR_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_BASE_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           $ErrorActionPreference = 'Stop'
 
-          $headRef = '${{ github.head_ref }}'
-          if ($headRef -notlike 'publish/*') {
-            throw "This public repository accepts proposal PRs for discussion, but release approval PRs must come from a publish/* branch created by the maintainer publication tooling."
+          function Test-OrdinalContains {
+            param(
+              [Parameter(Mandatory = $true)][string[]]$AllowedValues,
+              [Parameter(Mandatory = $true)][string]$Value
+            )
+
+            foreach ($allowedValue in $AllowedValues) {
+              if ([string]::Equals($allowedValue, $Value, [System.StringComparison]::Ordinal)) {
+                return $true
+              }
+            }
+            return $false
+          }
+
+          $headRef = [string]$env:PR_HEAD_REF
+          $headRepository = [string]$env:PR_HEAD_REPOSITORY
+          $baseRepository = [string]$env:PR_BASE_REPOSITORY
+          if ([string]::IsNullOrWhiteSpace($headRef) -or [string]::IsNullOrWhiteSpace($headRepository) -or [string]::IsNullOrWhiteSpace($baseRepository)) {
+            throw "Could not resolve public PR head branch and repository context."
+          }
+
+          if (-not [string]::Equals($headRepository, $baseRepository, [System.StringComparison]::OrdinalIgnoreCase)) {
+            throw "Community or fork PRs are proposal PRs for review only. Mergeable public publication PRs must come from this public repository through the maintainer publication workflow. Port accepted changes into the source workspace and republish through publish/v<version> or publish/metadata-<topic>."
+          }
+
+          $isReleaseApproval = $headRef -cmatch '^publish/v[0-9]+(?:\.[0-9]+)*$'
+          $isMetadataOnly = $headRef -cmatch '^publish/metadata-[a-z0-9][a-z0-9-]*$'
+          if (-not $isReleaseApproval -and -not $isMetadataOnly) {
+            throw "This public repository accepts proposal PRs for discussion, but mergeable maintainer PRs must use publish/v<version> for release approval or publish/metadata-<topic> for metadata-only publication."
           }
 
           $root = (Get-Location).Path
+          $baseSha = [string]$env:PR_BASE_SHA
+          $headSha = [string]$env:PR_HEAD_SHA
+          if ([string]::IsNullOrWhiteSpace($baseSha) -or [string]::IsNullOrWhiteSpace($headSha)) {
+            throw "Could not resolve public PR base/head SHAs."
+          }
+          $changedFiles = @(git diff --name-only $baseSha $headSha | ForEach-Object { $_ -replace '\\', '/' } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not resolve changed files for public PR validation."
+          }
+          if ($changedFiles.Count -eq 0) {
+            throw "Public PR contains no changed files."
+          }
+
+          $metadataOnlyAllowedFiles = @(
+            'README.md',
+            'README.ko-KR.md',
+            'LICENSE',
+            'THIRD_PARTY_NOTICES.md',
+            'THIRD_PARTY_NOTICES.ko-KR.md',
+            'SECURITY.md',
+            'SECURITY.ko-KR.md',
+            'SUPPORT.md',
+            'SUPPORT.ko-KR.md',
+            'CONTRIBUTING.md',
+            'CONTRIBUTING.ko-KR.md',
+            'CODE_OF_CONDUCT.md',
+            'CODE_OF_CONDUCT.ko-KR.md',
+            'assets/hero-screenshot.png',
+            '.github/ISSUE_TEMPLATE/bug_report.yml',
+            '.github/ISSUE_TEMPLATE/feature_request.yml',
+            '.github/ISSUE_TEMPLATE/support_question.yml',
+            '.github/ISSUE_TEMPLATE/config.yml',
+            '.github/FUNDING.yml',
+            '.github/PULL_REQUEST_TEMPLATE.md',
+            '.github/workflows/public-export-approval.yml'
+          )
+
+          if ($isMetadataOnly) {
+            foreach ($changedFile in $changedFiles) {
+              if (-not (Test-OrdinalContains -AllowedValues $metadataOnlyAllowedFiles -Value $changedFile)) {
+                throw "Metadata-only PR changed a non-metadata path: $changedFile"
+              }
+            }
+            Write-Host "Metadata-only public PR validation is limited to approved public metadata paths."
+          }
+
           $paths = @(Get-ChildItem -LiteralPath $root -Force -Recurse | Where-Object {
             $_.FullName -notmatch '[\\/]\.git([\\/]|$)'
           } | ForEach-Object {

--- a/CONTRIBUTING.ko-KR.md
+++ b/CONTRIBUTING.ko-KR.md
@@ -6,7 +6,7 @@
 
 이 공개 저장소는 스킨의 distribution surface이자 review surface입니다. 구현의 최종 원본 저장소가 아닙니다. 유지관리자가 준비한 릴리즈 브랜치는 실제 공개 릴리즈가 되기 전에 이곳에서 검토되며, 구현 변경은 먼저 유지관리자의 private development workspace에서 준비됩니다.
 
-커뮤니티 Pull Request는 proposal 및 검토 입력으로 환영합니다. 커뮤니티 PR이 public `main`에 직접 merge될 것을 기대하지 말아 주세요. proposal이 채택되면 maintainer가 private development workspace에 반영하고 그곳에서 검증한 뒤, maintainer release approval PR을 통해 이 공개 저장소에 다시 게시합니다.
+커뮤니티 Pull Request는 proposal 및 검토 입력으로 환영합니다. 커뮤니티 PR이 public `main`에 직접 merge될 것을 기대하지 말아 주세요. proposal이 채택되면 maintainer가 private development workspace에 반영하고 그곳에서 검증한 뒤, maintainer release approval PR 또는 maintainer metadata-only PR을 통해 이 공개 저장소에 다시 게시합니다.
 
 ## 시작 전에
 
@@ -17,7 +17,7 @@
 - Rainmeter `.ini`, `.inc` 파일은 UTF-16 LE BOM을 유지해야 합니다.
 - Lua 런타임 코드는 Lua 5.1 호환을 유지해야 합니다.
 - 빌드된 배포 트리, ZIP/RMSKIN release asset, 생성 캐시, 로컬 런타임 상태, 로그, 백업, 개인 경로는 커밋하지 마세요.
-- public-facing 문구는 사용자 친화적으로 유지하고, 내부 워크플로 용어는 쓰지 마세요.
+- public-facing 문구는 사용자 친화적으로 유지하고, private/internal workflow 용어는 피하되 PR 동작을 설명할 때 필요한 public branch/check policy 용어만 사용하세요.
 - Korea와 Global 패키지는 같은 스킨 폴더 `DMeloper's Block HUD`에 설치됩니다.
 
 ## Pull Request
@@ -30,13 +30,15 @@
 - 시각 변경이 있으면 스크린샷 또는 녹화
 - 패키징/업데이트 영향이 있으면 설명
 
-커뮤니티 Pull Request는 제안으로 검토됩니다. 변경 사항이 채택되면 유지관리자가 비공개 개발 작업 공간에 반영한 뒤, 릴리즈 승인 Pull Request를 통해 이 공개 저장소에 다시 게시합니다.
+커뮤니티 Pull Request는 제안으로 검토됩니다. 변경 사항이 채택되면 유지관리자가 비공개 개발 작업 공간에 반영한 뒤, 변경 유형에 따라 릴리즈 승인 Pull Request 또는 metadata-only Pull Request를 통해 이 공개 저장소에 다시 게시합니다.
 
-유지관리자가 공식 릴리즈 승인 PR을 준비하는 경우가 아니라면 `publish/v<version>` 브랜치를 만들지 마세요. `publish/v<version>` 브랜치 패턴과 `public-export-approval` 검사는 일반 커뮤니티 PR 요구 사항이 아니라 maintainer release approval 전용 도구입니다.
+유지관리자가 공식 릴리즈 승인 PR을 준비하는 경우가 아니라면 `publish/v<version>` 브랜치를 만들지 마세요. 유지관리자가 승인된 public metadata-only PR을 준비하는 경우가 아니라면 `publish/metadata-<topic>` 브랜치도 만들지 마세요. 이 브랜치 패턴들과 `public-export-approval` 검사는 일반 커뮤니티 PR 요구 사항이 아니라 maintainer publication 전용 도구입니다.
 
 커뮤니티 PR에서 `public-export-approval` 검사가 실패할 수 있습니다. 릴리즈 브랜치가 아닌 변경은 의도적으로 보호되기 때문이며, 이 실패가 proposal 논의나 리뷰 자체를 막는 신호는 아닙니다.
 
 릴리즈 승인 Pull Request는 maintainer 전용입니다. 이 PR은 `publish/v<version>` 브랜치를 사용하고, `public-export-approval` 검사를 통과해야 하며, 수동으로 merge된 뒤 GitHub Release tag와 assets가 확정됩니다.
+
+Metadata-only Pull Request도 maintainer 전용입니다. 이 PR은 `publish/metadata-<topic>` 브랜치를 사용하고, 승인된 public metadata 경로만 변경할 수 있으며, GitHub Release tag나 assets를 생성하거나 업데이트하지 않습니다.
 
 ## 공개 릴리즈 정책
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Contributions are welcome when they fit the project direction and can be reviewe
 
 This public repository is the distribution surface and review surface for the skin. It is not the implementation source of truth. Maintainer-owned release branches are reviewed here before they become public releases, while implementation changes are prepared in the maintainer's private development workspace first.
 
-Community pull requests are welcome as proposal and review input. Please do not expect a community PR to be merged directly into public `main`. If a proposal is accepted, the maintainer applies it in the private development workspace, validates it there, and publishes it back here through a maintainer release approval PR.
+Community pull requests are welcome as proposal and review input. Please do not expect a community PR to be merged directly into public `main`. If a proposal is accepted, the maintainer applies it in the private development workspace, validates it there, and publishes it back here through a maintainer release approval PR or a maintainer metadata-only PR.
 
 ## Before You Start
 
@@ -17,7 +17,7 @@ Open an issue first for larger changes, behavior changes, packaging changes, or 
 - Rainmeter `.ini` and `.inc` files must remain UTF-16 LE with BOM.
 - Lua runtime code should remain compatible with Lua 5.1.
 - Do not commit built distribution trees, ZIP/RMSKIN release assets, generated caches, local runtime state, logs, backups, or private paths.
-- Keep public-facing wording user-friendly and avoid internal workflow terminology.
+- Keep public-facing wording user-friendly and avoid private/internal workflow terminology; use public branch/check policy terms only where they explain pull request behavior.
 - Korea and Global packages install to the same skin folder: `DMeloper's Block HUD`.
 
 ## Pull Requests
@@ -30,13 +30,15 @@ Please include:
 - Screenshots or recordings for visual changes.
 - Any packaging or update implications.
 
-Community pull requests are treated as proposals. If a change is accepted, the maintainer will apply it through the private development workspace and publish it back here through a release approval pull request.
+Community pull requests are treated as proposals. If a change is accepted, the maintainer will apply it through the private development workspace and publish it back here through a release approval pull request or metadata-only pull request, depending on the change.
 
-Do not create `publish/v<version>` branches unless you are the maintainer preparing an official release approval PR. The `publish/v<version>` branch pattern and the `public-export-approval` check are maintainer release approval tools, not requirements for normal community PRs.
+Do not create `publish/v<version>` branches unless you are the maintainer preparing an official release approval PR. Do not create `publish/metadata-<topic>` branches unless you are the maintainer preparing an approved public metadata-only PR. These branch patterns and the `public-export-approval` check are maintainer publication tools, not requirements for normal community PRs.
 
 A community PR may show a failing `public-export-approval` check because non-release branches are intentionally guarded. That failure does not block discussion or review of the proposal.
 
 Release approval pull requests are maintainer-only. They use `publish/v<version>` branches, must pass the `public-export-approval` check, and are merged manually before the GitHub Release tag and assets are finalized.
+
+Metadata-only pull requests are also maintainer-only. They use `publish/metadata-<topic>` branches, may change only approved public metadata paths, and do not create or update GitHub Release tags or assets.
 
 ## Public Release Policy
 


### PR DESCRIPTION
## Summary / 요약

Maintainer metadata-only public PR. / 관리자 메타데이터 전용 공개 PR입니다.

This PR updates only source-owned public GitHub metadata. It does not publish a GitHub Release, tag, ZIP, RMSKIN, or runtime skin payload.
이 PR은 소스에서 관리하는 공개 GitHub 메타데이터만 업데이트합니다. GitHub Release, 태그, ZIP, RMSKIN 또는 런타임 스킨 페이로드를 게시하지 않습니다.

## Metadata Files / 메타데이터 파일
- CONTRIBUTING.md
- CONTRIBUTING.ko-KR.md
- .github/PULL_REQUEST_TEMPLATE.md
- .github/workflows/public-export-approval.yml

## Testing / 검증

- `tools/Publish-PublicGitHubMetadata.ps1` validated the selected files against the public metadata allowlist.
- 선택한 파일을 공개 메타데이터 허용 목록과 금지 콘텐츠 규칙으로 검증했습니다.
- `public-export-approval` must pass before merge.
- 병합 전에 public-export-approval 검사가 통과해야 합니다.