### PR TITLE
Add automated README badge snapshots

### DIFF
--- a/.github/workflows/public-export-approval.yml
+++ b/.github/workflows/public-export-approval.yml
@@ -90,13 +90,18 @@ jobs:
             'CODE_OF_CONDUCT.md',
             'CODE_OF_CONDUCT.ko-KR.md',
             'assets/hero-screenshot.png',
+            'assets/badges/release.svg',
+            'assets/badges/downloads.svg',
+            'assets/badges/stars.svg',
+            'assets/badges/license.svg',
             '.github/ISSUE_TEMPLATE/bug_report.yml',
             '.github/ISSUE_TEMPLATE/feature_request.yml',
             '.github/ISSUE_TEMPLATE/support_question.yml',
             '.github/ISSUE_TEMPLATE/config.yml',
             '.github/FUNDING.yml',
             '.github/PULL_REQUEST_TEMPLATE.md',
-            '.github/workflows/public-export-approval.yml'
+            '.github/workflows/public-export-approval.yml',
+            '.github/workflows/update-readme-badges.yml'
           )
 
           if ($isMetadataOnly) {
@@ -134,7 +139,8 @@ jobs:
             '.github/ISSUE_TEMPLATE/config.yml',
             '.github/FUNDING.yml',
             '.github/PULL_REQUEST_TEMPLATE.md',
-            '.github/workflows/public-export-approval.yml'
+            '.github/workflows/public-export-approval.yml',
+            '.github/workflows/update-readme-badges.yml'
           )
           foreach ($requiredFile in $requiredFiles) {
             if (-not (Test-Path -LiteralPath (Join-Path $root $requiredFile) -PathType Leaf)) {

--- a/.github/workflows/update-readme-badges.yml
+++ b/.github/workflows/update-readme-badges.yml
@@ -1,0 +1,198 @@
+name: update-readme-badges
+
+on:
+  schedule:
+    - cron: '17 3 */2 * *'
+  workflow_dispatch:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: readme-badges-${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.ref || 'scheduled-snapshot' }}
+  cancel-in-progress: false
+
+jobs:
+  update-readme-badges:
+    name: update-readme-badges
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'pull_request_target' ||
+      (
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        (
+          startsWith(github.event.pull_request.head.ref, 'publish/v') ||
+          startsWith(github.event.pull_request.head.ref, 'publish/metadata-')
+        )
+      )
+    env:
+      TARGET_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.ref || 'publish/metadata-readme-badge-snapshots' }}
+      BASE_REF: main
+      GITHUB_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Check out target branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.ref || 'main' }}
+          persist-credentials: true
+
+      - name: Refresh badge snapshots
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $allowedFiles = @(
+            'assets/badges/release.svg',
+            'assets/badges/downloads.svg',
+            'assets/badges/stars.svg',
+            'assets/badges/license.svg'
+          )
+
+          function Ensure-Directory {
+            param([Parameter(Mandatory = $true)][string]$Path)
+
+            if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+              New-Item -ItemType Directory -Path $Path -Force | Out-Null
+            }
+          }
+
+          function Escape-SvgText {
+            param([Parameter(Mandatory = $true)][string]$Text)
+
+            return [System.Security.SecurityElement]::Escape($Text)
+          }
+
+          function New-BadgeSvg {
+            param(
+              [Parameter(Mandatory = $true)][string]$Label,
+              [Parameter(Mandatory = $true)][string]$Message,
+              [Parameter(Mandatory = $true)][string]$LabelColor,
+              [Parameter(Mandatory = $true)][string]$MessageColor,
+              [string]$MessageTextColor = '#111111'
+            )
+
+            $displayLabel = $Label.ToUpperInvariant()
+            $displayMessage = $Message.ToUpperInvariant()
+            $labelWidth = [Math]::Max(76, 16 + ($displayLabel.Length * 8))
+            $messageWidth = [Math]::Max(54, 16 + ($displayMessage.Length * 8))
+            $width = $labelWidth + $messageWidth
+            $labelCenter = [Math]::Floor($labelWidth / 2)
+            $messageCenter = $labelWidth + [Math]::Floor($messageWidth / 2)
+            $labelText = Escape-SvgText -Text $displayLabel
+            $messageText = Escape-SvgText -Text $displayMessage
+
+            return @"
+          <svg xmlns="http://www.w3.org/2000/svg" width="$width" height="28" role="img" aria-label="${labelText}: ${messageText}">
+            <title>${labelText}: ${messageText}</title>
+            <rect width="$labelWidth" height="28" fill="$LabelColor"/>
+            <rect x="$labelWidth" width="$messageWidth" height="28" fill="$MessageColor"/>
+            <g fill="#ffffff" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11" font-weight="700" letter-spacing="1.2">
+              <text x="$labelCenter" y="18" text-anchor="middle">$labelText</text>
+            </g>
+            <g fill="$MessageTextColor" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11" font-weight="700" letter-spacing="1.2">
+              <text x="$messageCenter" y="18" text-anchor="middle">$messageText</text>
+            </g>
+          </svg>
+          "@
+          }
+
+          function Write-TextIfChanged {
+            param(
+              [Parameter(Mandatory = $true)][string]$Path,
+              [Parameter(Mandatory = $true)][string]$Text
+            )
+
+            if ((Test-Path -LiteralPath $Path -PathType Leaf) -and ([System.IO.File]::ReadAllText($Path) -ceq $Text)) {
+              return
+            }
+            [System.IO.File]::WriteAllText($Path, $Text, [System.Text.UTF8Encoding]::new($false))
+          }
+
+          $headers = @{
+            Authorization = "Bearer $env:GITHUB_TOKEN"
+            Accept = 'application/vnd.github+json'
+            'X-GitHub-Api-Version' = '2022-11-28'
+          }
+
+          $repo = Invoke-RestMethod -Headers $headers -Uri "https://api.github.com/repos/$env:GITHUB_REPOSITORY"
+          $releases = @(Invoke-RestMethod -Headers $headers -Uri "https://api.github.com/repos/$env:GITHUB_REPOSITORY/releases?per_page=100")
+          $stableReleases = @($releases | Where-Object { $_.draft -eq $false -and $_.prerelease -eq $false })
+          $latestRelease = $stableReleases | Select-Object -First 1
+          if ($null -eq $latestRelease) {
+            throw "No stable public release was found for $env:GITHUB_REPOSITORY."
+          }
+
+          $downloadCount = 0
+          foreach ($release in $stableReleases) {
+            foreach ($asset in @($release.assets)) {
+              $downloadCount += [int]$asset.download_count
+            }
+          }
+
+          $licenseText = 'MIT'
+          if ($null -ne $repo.license -and -not [string]::IsNullOrWhiteSpace([string]$repo.license.spdx_id) -and [string]$repo.license.spdx_id -ne 'NOASSERTION') {
+            $licenseText = [string]$repo.license.spdx_id
+          }
+
+          Ensure-Directory -Path 'assets/badges'
+          Write-TextIfChanged -Path 'assets/badges/release.svg' -Text (New-BadgeSvg -Label 'release' -Message ([string]$latestRelease.tag_name) -LabelColor '#2F334D' -MessageColor '#9FE870')
+          Write-TextIfChanged -Path 'assets/badges/downloads.svg' -Text (New-BadgeSvg -Label 'downloads' -Message ([string]$downloadCount) -LabelColor '#4A4F63' -MessageColor '#FFB07C')
+          Write-TextIfChanged -Path 'assets/badges/stars.svg' -Text (New-BadgeSvg -Label 'stars' -Message ([string]$repo.stargazers_count) -LabelColor '#2F334D' -MessageColor '#C6C4FF')
+          Write-TextIfChanged -Path 'assets/badges/license.svg' -Text (New-BadgeSvg -Label 'license' -Message $licenseText -LabelColor '#4A4F63' -MessageColor '#AED8FF')
+
+          $statusLines = @(git status --porcelain=v1 | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+          if ($statusLines.Count -eq 0) {
+            Write-Host 'Badge snapshots are already current.'
+            return
+          }
+
+          $changedFiles = @($statusLines | ForEach-Object { $_.Substring(3) -replace '\\', '/' })
+          foreach ($changedFile in $changedFiles) {
+            if ($allowedFiles -notcontains $changedFile) {
+              throw "Badge workflow changed an unauthorized path: $changedFile"
+            }
+          }
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add -- @allowedFiles
+
+          $stagedFiles = @(git diff --cached --name-only | ForEach-Object { $_ -replace '\\', '/' })
+          foreach ($stagedFile in $stagedFiles) {
+            if ($allowedFiles -notcontains $stagedFile) {
+              throw "Badge workflow staged an unauthorized path: $stagedFile"
+            }
+          }
+          if ($stagedFiles.Count -eq 0) {
+            Write-Host 'No badge changes were staged.'
+            return
+          }
+
+          git commit -m 'Update README badge snapshots'
+
+          if ('${{ github.event_name }}' -ne 'pull_request_target') {
+            git branch -M $env:TARGET_REF
+          }
+          git push origin "HEAD:$env:TARGET_REF"
+
+          if ('${{ github.event_name }}' -ne 'pull_request_target') {
+            $existingPr = @(gh pr list --head $env:TARGET_REF --base $env:BASE_REF --state open --json number,url --limit 1 | ConvertFrom-Json)
+            if ($existingPr.Count -gt 0) {
+              Write-Host "Updated existing badge snapshot PR: $($existingPr[0].url)"
+            }
+            else {
+              gh pr create `
+                --base $env:BASE_REF `
+                --head $env:TARGET_REF `
+                --title 'Update README badge snapshots' `
+                --body 'Automated metadata-only PR that refreshes the generated README badge SVG snapshots. No release assets, tags, or runtime skin files are changed.'
+            }
+          }

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -5,10 +5,10 @@
 [English](README.md) | 한국어
 
 <p align="center">
-  <a href="https://github.com/d-meloper/dmelopers-block-hud/releases/latest"><img alt="Latest release" src="https://img.shields.io/badge/release-v1.2.1-9FE870?style=for-the-badge&labelColor=2F334D"></a>
-  <a href="https://github.com/d-meloper/dmelopers-block-hud/releases"><img alt="Total downloads" src="https://img.shields.io/badge/downloads-429-FFB07C?style=for-the-badge&labelColor=4A4F63"></a>
-  <a href="https://github.com/d-meloper/dmelopers-block-hud/stargazers"><img alt="GitHub stars" src="https://img.shields.io/badge/stars-20-C6C4FF?style=for-the-badge&labelColor=2F334D"></a>
-  <a href="https://github.com/d-meloper/dmelopers-block-hud/blob/main/LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-AED8FF?style=for-the-badge&labelColor=4A4F63"></a>
+  <a href="https://github.com/d-meloper/dmelopers-block-hud/releases/latest"><img alt="Latest release" src="assets/badges/release.svg"></a>
+  <a href="https://github.com/d-meloper/dmelopers-block-hud/releases"><img alt="Total downloads" src="assets/badges/downloads.svg"></a>
+  <a href="https://github.com/d-meloper/dmelopers-block-hud/stargazers"><img alt="GitHub stars" src="assets/badges/stars.svg"></a>
+  <a href="https://github.com/d-meloper/dmelopers-block-hud/blob/main/LICENSE"><img alt="MIT License" src="assets/badges/license.svg"></a>
 </p>
 
 DMeloper's Block HUD는 Minecraft 스타일의 인벤토리와 핫바 UI에서 영감을 받은 비공식 Windows용 Rainmeter 스킨입니다.

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 English | [한국어](README.ko-KR.md)
 
 <p align="center">
-  <a href="https://github.com/d-meloper/dmelopers-block-hud/releases/latest"><img alt="Latest release" src="https://img.shields.io/badge/release-v1.2.1-9FE870?style=for-the-badge&labelColor=2F334D"></a>
-  <a href="https://github.com/d-meloper/dmelopers-block-hud/releases"><img alt="Total downloads" src="https://img.shields.io/badge/downloads-429-FFB07C?style=for-the-badge&labelColor=4A4F63"></a>
-  <a href="https://github.com/d-meloper/dmelopers-block-hud/stargazers"><img alt="GitHub stars" src="https://img.shields.io/badge/stars-20-C6C4FF?style=for-the-badge&labelColor=2F334D"></a>
-  <a href="https://github.com/d-meloper/dmelopers-block-hud/blob/main/LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-AED8FF?style=for-the-badge&labelColor=4A4F63"></a>
+  <a href="https://github.com/d-meloper/dmelopers-block-hud/releases/latest"><img alt="Latest release" src="assets/badges/release.svg"></a>
+  <a href="https://github.com/d-meloper/dmelopers-block-hud/releases"><img alt="Total downloads" src="assets/badges/downloads.svg"></a>
+  <a href="https://github.com/d-meloper/dmelopers-block-hud/stargazers"><img alt="GitHub stars" src="assets/badges/stars.svg"></a>
+  <a href="https://github.com/d-meloper/dmelopers-block-hud/blob/main/LICENSE"><img alt="MIT License" src="assets/badges/license.svg"></a>
 </p>
 
 DMeloper's Block HUD is an unofficial Windows Rainmeter skin inspired by Minecraft-style inventory and hotbar interfaces.

--- a/assets/badges/downloads.svg
+++ b/assets/badges/downloads.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="142" height="28" role="img" aria-label="DOWNLOADS: 429">
+  <title>DOWNLOADS: 429</title>
+  <rect width="88" height="28" fill="#4A4F63"/>
+  <rect x="88" width="54" height="28" fill="#FFB07C"/>
+  <g fill="#ffffff" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11" font-weight="700" letter-spacing="1.2">
+    <text x="44" y="18" text-anchor="middle">DOWNLOADS</text>
+  </g>
+  <g fill="#111111" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11" font-weight="700" letter-spacing="1.2">
+    <text x="115" y="18" text-anchor="middle">429</text>
+  </g>
+</svg>

--- a/assets/badges/license.svg
+++ b/assets/badges/license.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="130" height="28" role="img" aria-label="LICENSE: MIT">
+  <title>LICENSE: MIT</title>
+  <rect width="76" height="28" fill="#4A4F63"/>
+  <rect x="76" width="54" height="28" fill="#AED8FF"/>
+  <g fill="#ffffff" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11" font-weight="700" letter-spacing="1.2">
+    <text x="38" y="18" text-anchor="middle">LICENSE</text>
+  </g>
+  <g fill="#111111" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11" font-weight="700" letter-spacing="1.2">
+    <text x="103" y="18" text-anchor="middle">MIT</text>
+  </g>
+</svg>

--- a/assets/badges/release.svg
+++ b/assets/badges/release.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="28" role="img" aria-label="RELEASE: V1.2.1">
+  <title>RELEASE: V1.2.1</title>
+  <rect width="76" height="28" fill="#2F334D"/>
+  <rect x="76" width="64" height="28" fill="#9FE870"/>
+  <g fill="#ffffff" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11" font-weight="700" letter-spacing="1.2">
+    <text x="38" y="18" text-anchor="middle">RELEASE</text>
+  </g>
+  <g fill="#111111" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11" font-weight="700" letter-spacing="1.2">
+    <text x="108" y="18" text-anchor="middle">V1.2.1</text>
+  </g>
+</svg>

--- a/assets/badges/stars.svg
+++ b/assets/badges/stars.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="130" height="28" role="img" aria-label="STARS: 20">
+  <title>STARS: 20</title>
+  <rect width="76" height="28" fill="#2F334D"/>
+  <rect x="76" width="54" height="28" fill="#C6C4FF"/>
+  <g fill="#ffffff" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11" font-weight="700" letter-spacing="1.2">
+    <text x="38" y="18" text-anchor="middle">STARS</text>
+  </g>
+  <g fill="#111111" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11" font-weight="700" letter-spacing="1.2">
+    <text x="103" y="18" text-anchor="middle">20</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary / 요약

Maintainer metadata-only public PR. / 관리자 메타데이터 전용 공개 PR입니다.

This PR updates only source-owned public GitHub metadata. It does not publish a GitHub Release, tag, ZIP, RMSKIN, or runtime skin payload.
이 PR은 소스에서 관리하는 공개 GitHub 메타데이터만 업데이트합니다. GitHub Release, 태그, ZIP, RMSKIN 또는 런타임 스킨 페이로드를 게시하지 않습니다.

## Metadata Files / 메타데이터 파일
- README.md
- README.ko-KR.md
- assets/badges/release.svg
- assets/badges/downloads.svg
- assets/badges/stars.svg
- assets/badges/license.svg
- .github/workflows/update-readme-badges.yml
- .github/workflows/public-export-approval.yml

## Testing / 검증

- `tools/Publish-PublicGitHubMetadata.ps1` validated the selected files against the public metadata allowlist.
- 선택한 파일을 공개 메타데이터 허용 목록과 금지 콘텐츠 규칙으로 검증했습니다.
- `public-export-approval` must pass before merge.
- 병합 전에 public-export-approval 검사가 통과해야 합니다.