### PR TITLE
Update public metadata: readme-dynamic-badges

### DIFF
--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -5,9 +5,9 @@
 [English](README.md) | 한국어
 
 <p align="center">
-  <a href="https://github.com/d-meloper/dmelopers-block-hud/releases/latest"><img alt="Latest release" src="https://img.shields.io/badge/release-v1.2.1-9FE870?style=for-the-badge&labelColor=2F334D"></a>
-  <a href="https://github.com/d-meloper/dmelopers-block-hud/releases"><img alt="Total downloads" src="https://img.shields.io/badge/downloads-429-FFB07C?style=for-the-badge&labelColor=4A4F63"></a>
-  <a href="https://github.com/d-meloper/dmelopers-block-hud/stargazers"><img alt="GitHub stars" src="https://img.shields.io/badge/stars-20-C6C4FF?style=for-the-badge&labelColor=2F334D"></a>
+  <a href="https://github.com/d-meloper/dmelopers-block-hud/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/d-meloper/dmelopers-block-hud?style=for-the-badge&label=release&labelColor=2F334D&color=9FE870"></a>
+  <a href="https://github.com/d-meloper/dmelopers-block-hud/releases"><img alt="Total downloads" src="https://img.shields.io/github/downloads/d-meloper/dmelopers-block-hud/total?style=for-the-badge&label=downloads&labelColor=4A4F63&color=FFB07C"></a>
+  <a href="https://github.com/d-meloper/dmelopers-block-hud/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/d-meloper/dmelopers-block-hud?style=for-the-badge&label=stars&labelColor=2F334D&color=C6C4FF"></a>
   <a href="https://github.com/d-meloper/dmelopers-block-hud/blob/main/LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-AED8FF?style=for-the-badge&labelColor=4A4F63"></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 English | [한국어](README.ko-KR.md)
 
 <p align="center">
-  <a href="https://github.com/d-meloper/dmelopers-block-hud/releases/latest"><img alt="Latest release" src="https://img.shields.io/badge/release-v1.2.1-9FE870?style=for-the-badge&labelColor=2F334D"></a>
-  <a href="https://github.com/d-meloper/dmelopers-block-hud/releases"><img alt="Total downloads" src="https://img.shields.io/badge/downloads-429-FFB07C?style=for-the-badge&labelColor=4A4F63"></a>
-  <a href="https://github.com/d-meloper/dmelopers-block-hud/stargazers"><img alt="GitHub stars" src="https://img.shields.io/badge/stars-20-C6C4FF?style=for-the-badge&labelColor=2F334D"></a>
+  <a href="https://github.com/d-meloper/dmelopers-block-hud/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/d-meloper/dmelopers-block-hud?style=for-the-badge&label=release&labelColor=2F334D&color=9FE870"></a>
+  <a href="https://github.com/d-meloper/dmelopers-block-hud/releases"><img alt="Total downloads" src="https://img.shields.io/github/downloads/d-meloper/dmelopers-block-hud/total?style=for-the-badge&label=downloads&labelColor=4A4F63&color=FFB07C"></a>
+  <a href="https://github.com/d-meloper/dmelopers-block-hud/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/d-meloper/dmelopers-block-hud?style=for-the-badge&label=stars&labelColor=2F334D&color=C6C4FF"></a>
   <a href="https://github.com/d-meloper/dmelopers-block-hud/blob/main/LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-AED8FF?style=for-the-badge&labelColor=4A4F63"></a>
 </p>
 


### PR DESCRIPTION
## Summary / 요약

Maintainer metadata-only public PR. / 관리자 메타데이터 전용 공개 PR입니다.

This PR updates only source-owned public GitHub metadata. It does not publish a GitHub Release, tag, ZIP, RMSKIN, or runtime skin payload.
이 PR은 소스에서 관리하는 공개 GitHub 메타데이터만 업데이트합니다. GitHub Release, 태그, ZIP, RMSKIN 또는 런타임 스킨 페이로드를 게시하지 않습니다.

## Metadata Files / 메타데이터 파일
- README.md
- README.ko-KR.md

## Testing / 검증

- `tools/Publish-PublicGitHubMetadata.ps1` validated the selected files against the public metadata allowlist.
- 선택한 파일을 공개 메타데이터 허용 목록과 금지 콘텐츠 규칙으로 검증했습니다.
- `public-export-approval` must pass before merge.
- 병합 전에 public-export-approval 검사가 통과해야 합니다.