### PR TITLE
Publish v1.3.1

### DIFF
--- a/tools/ImportFromOldVersion.ps1
+++ b/tools/ImportFromOldVersion.ps1
@@ -2348,7 +2348,7 @@ function Get-SettingsBackfill {
 function Test-LegacyUpdaterZPosBootstrapSource {
     param([Parameter(Mandatory = $true)][version]$SourceVersion)
 
-    return ($SourceVersion -ge [version]'1.2.0' -and $SourceVersion -lt [version]'1.3.0')
+    return ($SourceVersion -ge [version]'1.2.0' -and $SourceVersion -lt [version]'1.3.1')
 }
 
 function Set-LegacyUpdaterZPosBootstrapPending {
@@ -2373,7 +2373,7 @@ function Set-LegacyUpdaterZPosBootstrapPending {
     $stateVariables = New-VariablesMap
     Set-MapValue -Map $stateVariables -Key 'BlockHudLegacyUpdaterZPosBootstrapPending' -Value '1'
     Write-Utf16Text -Path $statePath -Content (ConvertTo-VariablesContent -Variables $stateVariables)
-    Write-Log 'Legacy updater z-position bootstrap marker armed for v1.2.x source update.'
+    Write-Log 'Legacy updater z-position bootstrap marker armed for pre-v1.3.1 source update.'
 }
 
 function Replace-DirectorySnapshot {


### PR DESCRIPTION
Release approval for DMeloper's Block HUD v1.3.1.

This PR updates the public release branch contents. Review the diff and the `public-export-approval` check before squash merging.

```text
version: 1.3.1
tag: v1.3.1
branch: publish/v1.3.1
tree: 21a059f3259e50e7ea9966bb010d1283c3e6ba87
Korea ZIP: 58729E1551AE42C717A18D648ED79FB6E8AB674D4C02F8076598D138B604E020  DMelopers-Block-HUD_Korea.zip
Korea RMSKIN: 5A8282337A262AF81721A71E6C512EECD954FDE01790A684E46435F68CC76541  DMelopers-Block-HUD_Korea.rmskin
Global ZIP: 811FDDF5C19B0B9E0B05E4F381F0E0991D2A9568B23955428866E1168CAA2F9C  DMelopers-Block-HUD_Global.zip
Global RMSKIN: 766AF9129F1164E7FB55880589A3EEB81F5D4CBB2895FC01AB408651F5C9CE05  DMelopers-Block-HUD_Global.rmskin
```

After this PR is merged, finalize the release from the local approval manifest so the tag and release assets match this merged tree.