### PR TITLE
Allow badge automation metadata paths

### DIFF
--- a/.github/workflows/public-export-approval.yml
+++ b/.github/workflows/public-export-approval.yml
@@ -96,7 +96,9 @@ jobs:
             '.github/ISSUE_TEMPLATE/config.yml',
             '.github/FUNDING.yml',
             '.github/PULL_REQUEST_TEMPLATE.md',
-            '.github/workflows/public-export-approval.yml'
+            '.github/scripts/Update-PublicBadges.ps1',
+            '.github/workflows/public-export-approval.yml',
+            '.github/workflows/update-public-badges.yml'
           )
 
           if ($isMetadataOnly) {


### PR DESCRIPTION
Allows the public metadata approval workflow to accept the badge automation workflow and script paths before the full badge automation metadata PR is merged.