### PR TITLE
Update public workflows to checkout v6

### DIFF
--- a/.github/workflows/public-export-approval.yml
+++ b/.github/workflows/public-export-approval.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Check out pull request
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/update-public-badges.yml
+++ b/.github/workflows/update-public-badges.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Check out public main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
Updates public metadata workflows to use actions/checkout@v6 so badge and approval runs avoid the Node.js 20 deprecation warning. No release, tag, ZIP, .rmskin, or runtime payload is published.