### PR TITLE
Update public metadata: readme-docs

### DIFF
--- a/THIRD_PARTY_NOTICES.ko-KR.md
+++ b/THIRD_PARTY_NOTICES.ko-KR.md
@@ -13,6 +13,14 @@
 
 Mouse.dll은 서드파티 Rainmeter 플러그인으로 크레딧됩니다. DMeloper가 작성한 구성 요소가 아니며, 이 프로젝트의 MIT License로 재라이선스되지 않습니다.
 
+## WebNowPlaying
+
+- 프로젝트: WebNowPlaying-Rainmeter
+- 작성자: tjhrulz, keifufu
+- 출처: https://github.com/keifufu/WebNowPlaying-Rainmeter
+
+WebNowPlaying은 외부 음악 앱 연동에 사용되는 서드파티 Rainmeter 플러그인으로 크레딧됩니다. DMeloper가 작성한 구성 요소가 아니며, 이 프로젝트의 MIT License로 재라이선스되지 않습니다.
+
 ## Galmuri
 
 - 프로젝트: Galmuri

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -13,6 +13,14 @@ This project includes or credits third-party components and references.
 
 Mouse.dll is credited as a third-party Rainmeter plugin. It is not authored by DMeloper and is not relicensed by this project's MIT License.
 
+## WebNowPlaying
+
+- Project: WebNowPlaying-Rainmeter
+- Authors: tjhrulz, keifufu
+- Source: https://github.com/keifufu/WebNowPlaying-Rainmeter
+
+WebNowPlaying is credited as a third-party Rainmeter plugin used for external music app integration. It is not authored by DMeloper and is not relicensed by this project's MIT License.
+
 ## Galmuri
 
 - Project: Galmuri


### PR DESCRIPTION
## Summary / 요약

Maintainer metadata-only public PR. / 관리자 메타데이터 전용 공개 PR입니다.

This PR updates only source-owned public GitHub metadata. It does not publish a GitHub Release, tag, ZIP, RMSKIN, or runtime skin payload.
이 PR은 소스에서 관리하는 공개 GitHub 메타데이터만 업데이트합니다. GitHub Release, 태그, ZIP, RMSKIN 또는 런타임 스킨 페이로드를 게시하지 않습니다.

## Metadata Files / 메타데이터 파일
- README.md
- README.ko-KR.md
- THIRD_PARTY_NOTICES.md
- THIRD_PARTY_NOTICES.ko-KR.md

## Testing / 검증

- `tools/Publish-PublicGitHubMetadata.ps1` validated the selected files against the public metadata allowlist.
- 선택한 파일을 공개 메타데이터 허용 목록과 금지 콘텐츠 규칙으로 검증했습니다.
- `public-export-approval` must pass before merge.
- 병합 전에 public-export-approval 검사가 통과해야 합니다.