### PR TITLE
Update public metadata: readme-creator-link

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ When reporting a bug, include as much of the following information as possible.
 
 ## Credits
 
-- Skin creator: [DMeloper](https://litt.ly/dmeloper)
+- Skin creator: [DMeloper](https://linktr.ee/dmeloper.dev)
 - Rainmeter: https://github.com/rainmeter/rainmeter, https://www.rainmeter.net/
 - Mouse plugin: [Mouse.dll](https://github.com/NighthawkSLO/Mouse.dll), [@NighthawkSLO](https://github.com/NighthawkSLO), [@TheAzack9](https://github.com/TheAzack9)
 - WebNowPlaying: [WebNowPlaying-Rainmeter](https://github.com/keifufu/WebNowPlaying-Rainmeter) - [@tjhrulz](https://github.com/tjhrulz), [@keifufu](https://github.com/keifufu)


### PR DESCRIPTION
## Summary / 요약

Maintainer metadata-only public PR. / 관리자 메타데이터 전용 공개 PR입니다.

This PR updates only source-owned public GitHub metadata. It does not publish a GitHub Release, tag, ZIP, RMSKIN, or runtime skin payload.
이 PR은 소스에서 관리하는 공개 GitHub 메타데이터만 업데이트합니다. GitHub Release, 태그, ZIP, RMSKIN 또는 런타임 스킨 페이로드를 게시하지 않습니다.

## Metadata Files / 메타데이터 파일
- README.md

## Testing / 검증

- `tools/Publish-PublicGitHubMetadata.ps1` validated the selected files against the public metadata allowlist.
- 선택한 파일을 공개 메타데이터 허용 목록과 금지 콘텐츠 규칙으로 검증했습니다.
- `public-export-approval` must pass before merge.
- 병합 전에 public-export-approval 검사가 통과해야 합니다.