### PR TITLE
Bucket badge downloads by hundreds

### DIFF
--- a/.github/scripts/Update-PublicBadges.ps1
+++ b/.github/scripts/Update-PublicBadges.ps1
@@ -7,7 +7,8 @@ param(
     [string]$AppInstallationId = $env:DMEL_BADGE_APP_INSTALLATION_ID,
     [string]$OutputDirectory,
     [switch]$NoPush,
-    [switch]$SkipCamoPurge
+    [switch]$SkipCamoPurge,
+    [switch]$PolicySelfTest
 )
 
 Set-StrictMode -Version Latest
@@ -174,12 +175,21 @@ function ConvertTo-DisplayCount {
     param([Parameter(Mandatory = $true)][int]$Value)
 
     if ($Value -ge 1000000) {
-        return ('{0:0.#}M' -f ($Value / 1000000.0))
+        return [string]::Format([Globalization.CultureInfo]::InvariantCulture, '{0:0.####}M', ($Value / 1000000.0))
     }
     if ($Value -ge 1000) {
-        return ('{0:0.#}K' -f ($Value / 1000.0))
+        return [string]::Format([Globalization.CultureInfo]::InvariantCulture, '{0:0.#}K', ($Value / 1000.0))
     }
     return [string]$Value
+}
+
+function Get-DownloadBucket {
+    param([Parameter(Mandatory = $true)][int]$Value)
+
+    if ($Value -lt 0) {
+        throw 'Download count cannot be negative.'
+    }
+    return [int]([Math]::Floor($Value / 100.0) * 100)
 }
 
 function Escape-SvgText {
@@ -339,12 +349,12 @@ function Test-BadgePayloadValuesEqual {
         ([string]$ExistingPayload.RepoSlug -eq [string]$NewPayload.RepoSlug) -and
         ([string]$ExistingPayload.LatestRelease -eq [string]$NewPayload.LatestRelease) -and
         ([string]$ExistingPayload.LatestReleaseName -eq [string]$NewPayload.LatestReleaseName) -and
-        ([int]$ExistingPayload.TotalDownloads -eq [int]$NewPayload.TotalDownloads) -and
+        ((Get-DownloadBucket -Value ([int]$ExistingPayload.TotalDownloads)) -eq (Get-DownloadBucket -Value ([int]$NewPayload.TotalDownloads))) -and
         ([int]$ExistingPayload.Stars -eq [int]$NewPayload.Stars)
     )
 }
 
-function Resolve-BadgePayloadTimestamp {
+function Resolve-UnchangedBadgePayload {
     param(
         [object]$ExistingPayload,
         [Parameter(Mandatory = $true)][object]$NewPayload
@@ -367,6 +377,7 @@ function Resolve-BadgePayloadTimestamp {
                 Write-Warning "Existing GeneratedAtUtc is not ISO UTC; keeping raw value. $($_.Exception.Message)"
             }
         }
+        $NewPayload.TotalDownloads = [int]$ExistingPayload.TotalDownloads
         $NewPayload.GeneratedAtUtc = $existingTimestamp
     }
 
@@ -384,7 +395,8 @@ function Write-BadgeFiles {
     }
 
     $releaseSvg = New-BadgeSvg -Label 'RELEASE' -Message ([string]$Payload.LatestRelease) -LabelColor '2F334D' -MessageColor '9FE870'
-    $downloadsSvg = New-BadgeSvg -Label 'DOWNLOADS' -Message (ConvertTo-DisplayCount -Value ([int]$Payload.TotalDownloads)) -LabelColor '4A4F63' -MessageColor 'FFB07C'
+    $downloadBucket = Get-DownloadBucket -Value ([int]$Payload.TotalDownloads)
+    $downloadsSvg = New-BadgeSvg -Label 'DOWNLOADS' -Message (ConvertTo-DisplayCount -Value $downloadBucket) -LabelColor '4A4F63' -MessageColor 'FFB07C'
     $starsSvg = New-BadgeSvg -Label 'STARS' -Message (ConvertTo-DisplayCount -Value ([int]$Payload.Stars)) -LabelColor '2F334D' -MessageColor 'C6C4FF'
 
     Test-SafeBadgeSvg -Name 'release.svg' -Content $releaseSvg
@@ -476,7 +488,7 @@ function Update-BadgeBranch {
         if (($branchProbe -join "`n").Trim().Length -gt 0) {
             Invoke-Git -WorkingDirectory $repoPath -Arguments @('checkout', '-B', $BadgeBranch, "origin/$BadgeBranch") -FailureMessage 'Could not check out existing badge branch' | Out-Null
             Assert-OnlyAllowedBadgeTree -RepositoryPath $repoPath
-            $Payload = Resolve-BadgePayloadTimestamp -ExistingPayload (Get-ExistingBadgePayload -RepositoryPath $repoPath) -NewPayload $Payload
+            $Payload = Resolve-UnchangedBadgePayload -ExistingPayload (Get-ExistingBadgePayload -RepositoryPath $repoPath) -NewPayload $Payload
         }
         else {
             Invoke-Git -WorkingDirectory $repoPath -Arguments @('checkout', '--orphan', $BadgeBranch) -FailureMessage 'Could not create orphan badge branch' | Out-Null
@@ -546,6 +558,80 @@ function Invoke-CamoPurge {
             Write-Warning "Could not inspect rendered README page for Camo purge: $page - $($_.Exception.Message)"
         }
     }
+}
+
+function Invoke-BadgePolicySelfTest {
+    $displayCases = @(
+        @{ Value = 0; Bucket = 0; Display = '0' },
+        @{ Value = 99; Bucket = 0; Display = '0' },
+        @{ Value = 100; Bucket = 100; Display = '100' },
+        @{ Value = 199; Bucket = 100; Display = '100' },
+        @{ Value = 999; Bucket = 900; Display = '900' },
+        @{ Value = 1000; Bucket = 1000; Display = '1K' },
+        @{ Value = 1223; Bucket = 1200; Display = '1.2K' },
+        @{ Value = 1298; Bucket = 1200; Display = '1.2K' },
+        @{ Value = 1300; Bucket = 1300; Display = '1.3K' },
+        @{ Value = 1320; Bucket = 1300; Display = '1.3K' },
+        @{ Value = 1000000; Bucket = 1000000; Display = '1M' },
+        @{ Value = 1000100; Bucket = 1000100; Display = '1.0001M' }
+    )
+    foreach ($case in $displayCases) {
+        $bucket = Get-DownloadBucket -Value $case.Value
+        $display = ConvertTo-DisplayCount -Value $bucket
+        if ($bucket -ne $case.Bucket -or $display -ne $case.Display) {
+            throw "Download bucket test failed for $($case.Value): bucket=$bucket display=$display"
+        }
+    }
+
+    $base = [PSCustomObject]@{
+        RepoSlug = 'owner/repo'
+        GeneratedAtUtc = '2026-06-23T00:00:00.0000000+00:00'
+        GeneratedAtUtcRaw = '2026-06-23T00:00:00.0000000+00:00'
+        LatestRelease = 'v1.0.0'
+        LatestReleaseName = 'Release v1.0.0'
+        TotalDownloads = 1223
+        Stars = 10
+    }
+    $sameBucket = [PSCustomObject]@{
+        RepoSlug = 'owner/repo'
+        GeneratedAtUtc = '2026-06-23T06:00:00.0000000+00:00'
+        LatestRelease = 'v1.0.0'
+        LatestReleaseName = 'Release v1.0.0'
+        TotalDownloads = 1298
+        Stars = 10
+    }
+    if (-not (Test-BadgePayloadValuesEqual -ExistingPayload $base -NewPayload $sameBucket)) {
+        throw 'Same download bucket was incorrectly treated as changed.'
+    }
+    $resolved = Resolve-UnchangedBadgePayload -ExistingPayload $base -NewPayload $sameBucket
+    if ($resolved.TotalDownloads -ne 1223 -or $resolved.GeneratedAtUtc -ne $base.GeneratedAtUtcRaw) {
+        throw 'Unchanged badge values did not preserve the existing payload.'
+    }
+
+    foreach ($change in @(
+        @{ Name = 'download bucket'; Downloads = 1320; Stars = 10; Release = 'v1.0.0' },
+        @{ Name = 'stars'; Downloads = 1298; Stars = 11; Release = 'v1.0.0' },
+        @{ Name = 'release'; Downloads = 1298; Stars = 10; Release = 'v1.0.1' }
+    )) {
+        $candidate = [PSCustomObject]@{
+            RepoSlug = 'owner/repo'
+            GeneratedAtUtc = '2026-06-23T06:00:00.0000000+00:00'
+            LatestRelease = $change.Release
+            LatestReleaseName = if ($change.Release -eq 'v1.0.0') { 'Release v1.0.0' } else { 'Release v1.0.1' }
+            TotalDownloads = $change.Downloads
+            Stars = $change.Stars
+        }
+        if (Test-BadgePayloadValuesEqual -ExistingPayload $base -NewPayload $candidate) {
+            throw "$($change.Name) change was incorrectly treated as unchanged."
+        }
+    }
+
+    Write-Host 'Badge policy self-test passed.'
+}
+
+if ($PolicySelfTest) {
+    Invoke-BadgePolicySelfTest
+    return
 }
 
 $apiToken = $null


### PR DESCRIPTION
Updates badge automation to display and compare total downloads using floor-based 100-count buckets, preserving the prior payload when release, stars, and the download bucket are unchanged. No release, tag, ZIP, .rmskin, or runtime payload is published.