### PR TITLE
Include prerelease badge downloads

### DIFF
--- a/.github/scripts/Update-PublicBadges.ps1
+++ b/.github/scripts/Update-PublicBadges.ps1
@@ -109,7 +109,31 @@ function Invoke-GitHubApi {
     return $result
 }
 
-function Get-AllStableReleases {
+function Select-PublishedReleases {
+    param([Parameter(Mandatory = $true)][object[]]$Releases)
+
+    return @($Releases | Where-Object { -not [bool]$_.draft })
+}
+
+function Select-StableReleases {
+    param([Parameter(Mandatory = $true)][object[]]$Releases)
+
+    return @($Releases | Where-Object { -not [bool]$_.draft -and -not [bool]$_.prerelease })
+}
+
+function Get-TotalReleaseAssetDownloads {
+    param([Parameter(Mandatory = $true)][object[]]$Releases)
+
+    $total = 0
+    foreach ($release in $Releases) {
+        foreach ($asset in @($release.assets)) {
+            $total += [int]$asset.download_count
+        }
+    }
+    return $total
+}
+
+function Get-AllPublishedReleases {
     param(
         [Parameter(Mandatory = $true)][string]$RepoSlug,
         [string]$Token
@@ -122,10 +146,8 @@ function Get-AllStableReleases {
         if ($items.Count -eq 0) {
             break
         }
-        foreach ($item in $items) {
-            if (-not [bool]$item.draft -and -not [bool]$item.prerelease) {
-                [void]$all.Add($item)
-            }
+        foreach ($item in @(Select-PublishedReleases -Releases $items)) {
+            [void]$all.Add($item)
         }
         if ($items.Count -lt 100) {
             break
@@ -290,17 +312,13 @@ function Get-BadgePayload {
     )
 
     $repo = Invoke-GitHubApi -Path "repos/$RepoSlug" -Token $Token
-    $releases = @(Get-AllStableReleases -RepoSlug $RepoSlug -Token $Token)
-    if ($releases.Count -eq 0) {
+    $publishedReleases = @(Get-AllPublishedReleases -RepoSlug $RepoSlug -Token $Token)
+    $stableReleases = @(Select-StableReleases -Releases $publishedReleases)
+    if ($stableReleases.Count -eq 0) {
         throw "No stable GitHub releases found for $RepoSlug."
     }
-    $latest = Get-LatestStableRelease -Releases $releases
-    $downloadCount = 0
-    foreach ($release in $releases) {
-        foreach ($asset in @($release.assets)) {
-            $downloadCount += [int]$asset.download_count
-        }
-    }
+    $latest = Get-LatestStableRelease -Releases $stableReleases
+    $downloadCount = Get-TotalReleaseAssetDownloads -Releases $publishedReleases
 
     return [PSCustomObject]@{
         RepoSlug = $RepoSlug
@@ -561,6 +579,38 @@ function Invoke-CamoPurge {
 }
 
 function Invoke-BadgePolicySelfTest {
+    $releaseFixtures = @(
+        [PSCustomObject]@{
+            draft = $false
+            prerelease = $false
+            tag_name = 'v1.0.0'
+            assets = @([PSCustomObject]@{ download_count = 100 })
+        },
+        [PSCustomObject]@{
+            draft = $false
+            prerelease = $true
+            tag_name = 'v1.1.0-beta.1'
+            assets = @(
+                [PSCustomObject]@{ download_count = 20 },
+                [PSCustomObject]@{ download_count = 30 }
+            )
+        },
+        [PSCustomObject]@{
+            draft = $true
+            prerelease = $false
+            tag_name = 'v2.0.0-draft'
+            assets = @([PSCustomObject]@{ download_count = 1000 })
+        }
+    )
+    $publishedFixtures = @(Select-PublishedReleases -Releases $releaseFixtures)
+    $stableFixtures = @(Select-StableReleases -Releases $publishedFixtures)
+    if ($publishedFixtures.Count -ne 2 -or $stableFixtures.Count -ne 1) {
+        throw 'Published/stable release selection policy test failed.'
+    }
+    if ((Get-TotalReleaseAssetDownloads -Releases $publishedFixtures) -ne 150) {
+        throw 'Prerelease downloads were not included or draft downloads were not excluded.'
+    }
+
     $displayCases = @(
         @{ Value = 0; Bucket = 0; Display = '0' },
         @{ Value = 99; Bucket = 0; Display = '0' },


### PR DESCRIPTION
Includes assets from stable and prerelease GitHub Releases in the total download badge while excluding drafts and keeping the release-version badge stable-only. No release, tag, ZIP, .rmskin, or runtime payload is published.