### PR TITLE
Restore prerelease badge download totals

### DIFF
--- a/.github/scripts/Update-PublicBadges.ps1
+++ b/.github/scripts/Update-PublicBadges.ps1
@@ -108,7 +108,31 @@ function Invoke-GitHubApi {
     return $result
 }
 
-function Get-AllStableReleases {
+function Select-PublishedReleases {
+    param([Parameter(Mandatory = $true)][object[]]$Releases)
+
+    return @($Releases | Where-Object { -not [bool]$_.draft })
+}
+
+function Select-StableReleases {
+    param([Parameter(Mandatory = $true)][object[]]$Releases)
+
+    return @($Releases | Where-Object { -not [bool]$_.draft -and -not [bool]$_.prerelease })
+}
+
+function Get-TotalReleaseAssetDownloads {
+    param([Parameter(Mandatory = $true)][object[]]$Releases)
+
+    $total = 0
+    foreach ($release in $Releases) {
+        foreach ($asset in @($release.assets)) {
+            $total += [int]$asset.download_count
+        }
+    }
+    return $total
+}
+
+function Get-AllPublishedReleases {
     param(
         [Parameter(Mandatory = $true)][string]$RepoSlug,
         [string]$Token
@@ -121,10 +145,8 @@ function Get-AllStableReleases {
         if ($items.Count -eq 0) {
             break
         }
-        foreach ($item in $items) {
-            if (-not [bool]$item.draft -and -not [bool]$item.prerelease) {
-                [void]$all.Add($item)
-            }
+        foreach ($item in @(Select-PublishedReleases -Releases $items)) {
+            [void]$all.Add($item)
         }
         if ($items.Count -lt 100) {
             break
@@ -280,17 +302,13 @@ function Get-BadgePayload {
     )
 
     $repo = Invoke-GitHubApi -Path "repos/$RepoSlug" -Token $Token
-    $releases = @(Get-AllStableReleases -RepoSlug $RepoSlug -Token $Token)
-    if ($releases.Count -eq 0) {
+    $publishedReleases = @(Get-AllPublishedReleases -RepoSlug $RepoSlug -Token $Token)
+    $stableReleases = @(Select-StableReleases -Releases $publishedReleases)
+    if ($stableReleases.Count -eq 0) {
         throw "No stable GitHub releases found for $RepoSlug."
     }
-    $latest = Get-LatestStableRelease -Releases $releases
-    $downloadCount = 0
-    foreach ($release in $releases) {
-        foreach ($asset in @($release.assets)) {
-            $downloadCount += [int]$asset.download_count
-        }
-    }
+    $latest = Get-LatestStableRelease -Releases $stableReleases
+    $downloadCount = Get-TotalReleaseAssetDownloads -Releases $publishedReleases
 
     return [PSCustomObject]@{
         RepoSlug = $RepoSlug


### PR DESCRIPTION
## Summary / 요약

Maintainer metadata-only public PR. / 관리자 메타데이터 전용 공개 PR입니다.

This PR updates only source-owned public GitHub metadata. It does not publish a GitHub Release, tag, ZIP, RMSKIN, or runtime skin payload.
이 PR은 소스에서 관리하는 공개 GitHub 메타데이터만 업데이트합니다. GitHub Release, 태그, ZIP, RMSKIN 또는 런타임 스킨 페이로드를 게시하지 않습니다.

## Metadata Files / 메타데이터 파일
- .github/scripts/Update-PublicBadges.ps1

## Testing / 검증

- `tools/Publish-PublicGitHubMetadata.ps1` validated the selected files against the public metadata allowlist.
- 선택한 파일을 공개 메타데이터 허용 목록과 금지 콘텐츠 규칙으로 검증했습니다.
- `public-export-approval` must pass before merge.
- 병합 전에 public-export-approval 검사가 통과해야 합니다.