### PR TITLE
Update v1.4 package guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     id: skin-version
     attributes:
       label: Skin version / 스킨 버전
-      placeholder: "v1.1.6"
+      placeholder: "vX.Y.Z"
     validations:
       required: true
   - type: dropdown

--- a/CONTRIBUTING.ko-KR.md
+++ b/CONTRIBUTING.ko-KR.md
@@ -18,7 +18,7 @@
 - Lua 런타임 코드는 Lua 5.1 호환을 유지해야 합니다.
 - 빌드된 배포 트리, ZIP/RMSKIN release asset, 생성 캐시, 로컬 런타임 상태, 로그, 백업, 개인 경로는 커밋하지 마세요.
 - public-facing 문구는 사용자 친화적으로 유지하고, private/internal workflow 용어는 피하되 PR 동작을 설명할 때 필요한 public branch/check policy 용어만 사용하세요.
-- Korea와 Global 패키지는 같은 스킨 폴더 `DMeloper's Block HUD`에 설치됩니다.
+- updater ZIP 패키지는 고정 wrapper 루트 `DMeloper's Block HUD`를 사용합니다. 수동 `.rmskin` 패키지는 `DMeloper's Block HUD Korea v<version>` 및 `DMeloper's Block HUD Global v<version>`처럼 variant와 버전별 루트를 사용합니다.
 
 ## Pull Request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Open an issue first for larger changes, behavior changes, packaging changes, or 
 - Lua runtime code should remain compatible with Lua 5.1.
 - Do not commit built distribution trees, ZIP/RMSKIN release assets, generated caches, local runtime state, logs, backups, or private paths.
 - Keep public-facing wording user-friendly and avoid private/internal workflow terminology; use public branch/check policy terms only where they explain pull request behavior.
-- Korea and Global packages install to the same skin folder: `DMeloper's Block HUD`.
+- Updater ZIP packages use the fixed wrapper root `DMeloper's Block HUD`. Manual `.rmskin` packages use variant- and version-specific roots: `DMeloper's Block HUD Korea v<version>` and `DMeloper's Block HUD Global v<version>`.
 
 ## Pull Requests
 

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -48,7 +48,7 @@ GitHub에서 직접 설치하려는 경우에는 반드시 `.rmskin` 파일을 �
 
 한국어 사용자는 `DMelopers-Block-HUD_Korea.rmskin`을 내려받는 것을 권장합니다. 영어 또는 글로벌 환경 사용자는 `DMelopers-Block-HUD_Global.rmskin`을 사용하세요.
 
-두 variant는 모두 같은 Rainmeter 스킨 폴더인 `DMeloper's Block HUD`에 설치되므로, 나란히 공존하도록 설계되지 않았습니다. 한 variant 위에 다른 variant를 설치하면 기존 스킨 폴더가 덮어써질 수 있습니다.
+`.rmskin` 패키지는 `DMeloper's Block HUD Korea v<version>` 및 `DMeloper's Block HUD Global v<version>`처럼 variant와 버전이 포함된 별도 스킨 폴더에 설치됩니다. 두 설치본은 나란히 공존할 수 있으며, 관리하거나 삭제할 때 해당 폴더를 선택하세요.
 
 업데이트는 가능하면 스킨에 포함된 `Skin manager`를 사용하세요. `Skin manager`는 과거 릴리즈 목록 전체를 불러오지 않고 현재 설치된 variant의 검증된 최신 릴리즈 정보를 확인해 맞는 ZIP 패키지를 적용합니다. 호환되는 설정, 아이템, 사용자 이미지와 로컬 음원은 새 설치본으로 이어지며, 일부 아이템 이미지 필드를 사용할 수 없는 경우에는 해당 필드만 비우기 전에 확인을 요청합니다. GitHub에서 수동으로 다시 설치하려는 경우에는 `.rmskin` 파일을 사용하세요.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Use an `.rmskin` file when installing directly from GitHub. The `.zip` files are
 
 Korean users should download `DMelopers-Block-HUD_Korea.rmskin`. English and global users should use `DMelopers-Block-HUD_Global.rmskin`.
 
-Both variants install to the same Rainmeter skin folder, `DMeloper's Block HUD`, so they are not designed to coexist side by side. Installing one variant over the other can overwrite the existing skin folder.
+The `.rmskin` packages install to separate versioned skin folders: `DMeloper's Block HUD Korea v<version>` and `DMeloper's Block HUD Global v<version>`. They can coexist side by side; use the corresponding folder when managing or removing an installation.
 
 For updates, use the in-skin `Skin manager` whenever possible. It checks validated latest-release data for the installed variant and applies the matching ZIP package without loading a historical release list. Compatible settings, items, user images, and local audio are carried into the new install; if some item-image fields cannot be used, the skin asks before clearing only those fields. Use an `.rmskin` file when reinstalling manually from GitHub.
 


### PR DESCRIPTION
## English

### Summary

Maintainer metadata-only public PR.

This PR updates only source-owned public GitHub metadata. It does not publish a GitHub Release, tag, ZIP, RMSKIN, or runtime skin payload.

### Metadata Files
- README.md
- README.ko-KR.md
- CONTRIBUTING.md
- CONTRIBUTING.ko-KR.md
- .github/ISSUE_TEMPLATE/bug_report.yml

### Testing

- `tools/Publish-PublicGitHubMetadata.ps1` validated the selected files against the public metadata allowlist.
- `public-export-approval` must pass before merge.

## 한국어

### 요약

관리자 메타데이터 전용 공개 PR입니다.

이 PR은 소스에서 관리하는 공개 GitHub 메타데이터만 업데이트합니다. GitHub Release, 태그, ZIP, RMSKIN 또는 런타임 스킨 페이로드를 게시하지 않습니다.

### 메타데이터 파일
- README.md
- README.ko-KR.md
- CONTRIBUTING.md
- CONTRIBUTING.ko-KR.md
- .github/ISSUE_TEMPLATE/bug_report.yml

### 검증

- 선택한 파일을 공개 메타데이터 허용 목록과 금지 콘텐츠 규칙으로 검증했습니다.
- 병합 전에 public-export-approval 검사가 통과해야 합니다.