### PR TITLE
Document updater integrity verification policy

### DIFF
--- a/SECURITY.ko-KR.md
+++ b/SECURITY.ko-KR.md
@@ -6,6 +6,22 @@
 
 별도 정책이 추가되지 않는 한, 보안 수정은 최신 public GitHub release에만 제공합니다.
 
+## 릴리스 및 업데이터 무결성
+
+릴리스 노트에는 배포되는 각 ZIP 및 RMSKIN asset의 정확한 `SHA256 <hash> <asset>` 항목을 게시합니다. 공개 updater feed는 해당 릴리스 노트 항목과 GitHub release asset의 `sha256:` digest가 모두 존재하고 서로 일치할 때만 Korea 또는 Global updater ZIP의 hash를 게시합니다.
+
+Checksum 검증 updater를 포함한 첫 릴리스부터 네트워크 기반 update와 현재 버전 reset은 검증 실패 시 안전하게 중단됩니다.
+
+- Repository, variant, 정확한 asset 이름과 SHA-256은 동일한 검증 metadata에서 가져와야 합니다.
+- 다운로드한 ZIP은 staging 직후와 압축 해제 직전에 다시 검사합니다.
+- Metadata나 package byte가 누락, 형식 오류, stale 또는 불일치 상태이면 압축 해제, compatibility 처리, 사용자 상태 변경 전에 작업을 중단합니다.
+
+버전 1.4.0 및 이전 버전에는 이 runtime 검증이 소급 적용되지 않습니다. 기존 local package 및 import workflow는 compatibility 경로로 유지되며, network 또는 latest-update handoff로 호출되지 않는 한 공개 checksum을 요구하지 않습니다.
+
+수동 다운로드 파일은 PowerShell에서 `Get-FileHash <file> -Algorithm SHA256`을 실행한 뒤 정확히 같은 파일 이름의 릴리스 노트 항목과 비교할 수 있습니다. Updater가 checksum 불일치를 알리면 우회하지 말고 version, variant, asset 이름, expected hash와 actual hash를 보존한 뒤 비공개로 제보해주세요.
+
+SHA-256은 다운로드 손상, 잘못되었거나 교체된 asset, publication metadata drift를 감지합니다. Software의 악성 여부나 publisher 신원을 증명하지 않으며, 공격자가 artifact와 신뢰하는 checksum metadata를 모두 교체할 수 있는 상황까지 방어하지는 않습니다. 현재 Block HUD는 code signing 또는 TUF 방식의 signed metadata 보호를 제공한다고 주장하지 않습니다.
+
 ## 취약점 제보 방법
 
 보안 문제를 공개 GitHub Issue로 올리지 마세요.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,22 @@ English | [한국어](SECURITY.ko-KR.md)
 
 Security fixes are provided for the latest public GitHub release only unless a later policy explicitly states otherwise.
 
+## Release And Updater Integrity
+
+Release notes publish an exact `SHA256 <hash> <asset>` entry for each distributed ZIP and RMSKIN asset. The public updater feed publishes a Korea or Global updater ZIP hash only when that exact release-note entry and the GitHub release asset's `sha256:` digest both exist and agree.
+
+Beginning with the first release that contains checksum-verifying updater support, network-driven updates and current-version resets fail closed:
+
+- Repository, variant, exact asset name, and SHA-256 must come from the same verified metadata.
+- The downloaded ZIP is checked after staging and again immediately before extraction.
+- Missing, malformed, stale, or mismatched metadata or package bytes stop the operation before extraction, compatibility processing, or user-state changes.
+
+Version 1.4.0 and earlier do not retroactively gain this runtime verification. Existing local package and import workflows remain compatibility paths and do not require a published checksum unless they are invoked through a network or latest-update handoff.
+
+For a manual download, run `Get-FileHash <file> -Algorithm SHA256` in PowerShell and compare the result with the release-note entry for the exact filename. If the updater reports a checksum mismatch, do not bypass it; retain the version, variant, asset name, expected hash, and actual hash, then report the issue privately.
+
+SHA-256 detects corruption, an incorrect or replaced asset, and publication metadata drift. It does not determine whether software is malware, prove publisher identity, or protect against an attacker who can replace both an artifact and all trusted checksum metadata. Block HUD does not currently claim code-signing or TUF-style signed metadata protection.
+
 ## Reporting A Vulnerability
 
 Do not report security issues in public GitHub Issues.


### PR DESCRIPTION
## English

### Summary

Maintainer metadata-only public PR.

This PR updates only source-owned public GitHub metadata. It does not publish a GitHub Release, tag, ZIP, RMSKIN, or runtime skin payload.

### Metadata Files
- SECURITY.md
- SECURITY.ko-KR.md

### Testing

- `tools/Publish-PublicGitHubMetadata.ps1` validated the selected files against the public metadata allowlist.
- `public-export-approval` must pass before merge.

## 한국어

### 요약

관리자 메타데이터 전용 공개 PR입니다.

이 PR은 소스에서 관리하는 공개 GitHub 메타데이터만 업데이트합니다. GitHub Release, 태그, ZIP, RMSKIN 또는 런타임 스킨 페이로드를 게시하지 않습니다.

### 메타데이터 파일
- SECURITY.md
- SECURITY.ko-KR.md

### 검증

- 선택한 파일을 공개 메타데이터 허용 목록과 금지 콘텐츠 규칙으로 검증했습니다.
- 병합 전에 public-export-approval 검사가 통과해야 합니다.