### PR TITLE
Update public metadata: rmskin-download-badge

### DIFF
--- a/.github/scripts/Update-PublicBadges.ps1
+++ b/.github/scripts/Update-PublicBadges.ps1
@@ -121,12 +121,16 @@ function Select-StableReleases {
     return @($Releases | Where-Object { -not [bool]$_.draft -and -not [bool]$_.prerelease })
 }
 
-function Get-TotalReleaseAssetDownloads {
+function Get-TotalRmskinDownloads {
     param([Parameter(Mandatory = $true)][object[]]$Releases)
 
     $total = 0
     foreach ($release in $Releases) {
         foreach ($asset in @($release.assets)) {
+            $assetName = [string]$asset.name
+            if (-not $assetName.EndsWith('.rmskin', [System.StringComparison]::OrdinalIgnoreCase)) {
+                continue
+            }
             $total += [int]$asset.download_count
         }
     }
@@ -387,7 +391,7 @@ function Get-BadgePayload {
     $latestGlobal = Get-LatestStableReleaseWithAsset -Releases $stableReleases -AssetName $globalAssetName
     $latestKoreaSha256 = Get-ReleaseAssetSha256 -Release $latestKorea -AssetName $koreaAssetName
     $latestGlobalSha256 = Get-ReleaseAssetSha256 -Release $latestGlobal -AssetName $globalAssetName
-    $downloadCount = Get-TotalReleaseAssetDownloads -Releases $publishedReleases
+    $downloadCount = Get-TotalRmskinDownloads -Releases $publishedReleases
 
     return [PSCustomObject]@{
         SchemaVersion = 3

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/d-meloper/dmelopers-block-hud/releases/latest"><img alt="Latest release" src="https://raw.githubusercontent.com/d-meloper/dmelopers-block-hud/badges/release.svg"></a>
-  <a href="https://github.com/d-meloper/dmelopers-block-hud/releases"><img alt="Total downloads" src="https://raw.githubusercontent.com/d-meloper/dmelopers-block-hud/badges/downloads.svg"></a>
+  <a href="https://github.com/d-meloper/dmelopers-block-hud/releases"><img alt="RMSKIN 다운로드" src="https://raw.githubusercontent.com/d-meloper/dmelopers-block-hud/badges/downloads.svg"></a>
   <a href="https://github.com/d-meloper/dmelopers-block-hud/stargazers"><img alt="GitHub stars" src="https://raw.githubusercontent.com/d-meloper/dmelopers-block-hud/badges/stars.svg"></a>
   <a href="https://github.com/d-meloper/dmelopers-block-hud/blob/main/LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-AED8FF?style=for-the-badge&labelColor=4A4F63"></a>
 </p>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ English | [한국어](README.ko-KR.md)
 
 <p align="center">
   <a href="https://github.com/d-meloper/dmelopers-block-hud/releases/latest"><img alt="Latest release" src="https://raw.githubusercontent.com/d-meloper/dmelopers-block-hud/badges/release.svg"></a>
-  <a href="https://github.com/d-meloper/dmelopers-block-hud/releases"><img alt="Total downloads" src="https://raw.githubusercontent.com/d-meloper/dmelopers-block-hud/badges/downloads.svg"></a>
+  <a href="https://github.com/d-meloper/dmelopers-block-hud/releases"><img alt="RMSKIN downloads" src="https://raw.githubusercontent.com/d-meloper/dmelopers-block-hud/badges/downloads.svg"></a>
   <a href="https://github.com/d-meloper/dmelopers-block-hud/stargazers"><img alt="GitHub stars" src="https://raw.githubusercontent.com/d-meloper/dmelopers-block-hud/badges/stars.svg"></a>
   <a href="https://github.com/d-meloper/dmelopers-block-hud/blob/main/LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-AED8FF?style=for-the-badge&labelColor=4A4F63"></a>
 </p>


### PR DESCRIPTION
## English

### Summary

Maintainer metadata-only public PR.

This PR updates only source-owned public GitHub metadata. It does not publish a GitHub Release, tag, ZIP, RMSKIN, or runtime skin payload.

### Metadata Files
- README.md
- README.ko-KR.md
- .github/scripts/Update-PublicBadges.ps1

### Testing

- `tools/Publish-PublicGitHubMetadata.ps1` validated the selected files against the public metadata allowlist.
- `public-export-approval` must pass before merge.

## 한국어

### 요약

관리자 메타데이터 전용 공개 PR입니다.

이 PR은 소스에서 관리하는 공개 GitHub 메타데이터만 업데이트합니다. GitHub Release, 태그, ZIP, RMSKIN 또는 런타임 스킨 페이로드를 게시하지 않습니다.

### 메타데이터 파일
- README.md
- README.ko-KR.md
- .github/scripts/Update-PublicBadges.ps1

### 검증

- 선택한 파일을 공개 메타데이터 허용 목록과 금지 콘텐츠 규칙으로 검증했습니다.
- 병합 전에 public-export-approval 검사가 통과해야 합니다.